### PR TITLE
Updates o-footer to 5.3.1

### DIFF
--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-footer@^5.0.3">
+<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-footer@^5.3.1">
 <footer class="o-footer o-footer--theme-dark" data-o-component="o-footer" data-o-footer--no-js="">
 	<div class="o-footer__container">
 
@@ -54,7 +54,7 @@
 					<div class="o-footer__matrix-content" id="o-footer-section-3">
 							<div class="o-footer__matrix-column">
 									<a class="o-footer__matrix-link" href="//markets.ft.com/data/portfolio/dashboard">Portfolio</a>
-									<a class="o-footer__matrix-link" href="//ftepaper.ft.com">Today&apos;s Paper</a>
+									<a class="o-footer__matrix-link" href="//ftepaper.ft.com">Today's Paper</a>
 									<a class="o-footer__matrix-link" href="//markets.ft.com/data/alerts/">Alerts Hub</a>
 									<a class="o-footer__matrix-link" href="//lexicon.ft.com/">Lexicon</a>
 									<a class="o-footer__matrix-link" href="//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016">MBA Rankings</a>
@@ -67,60 +67,17 @@
 							</div>
 					</div>
 				</div>
-				<div class="o-footer__matrix-group o-footer__matrix-group--6">
-					<h6 class="o-footer__matrix-title" aria-controls="o-footer-section-4">
-						More from FT Group
-					</h6>
-					<div class="o-footer__matrix-content" id="o-footer-section-4">
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.agendaweek.com/">Agenda</a>
-									<a class="o-footer__matrix-link" href="//www.analyseafrica.com/">Analyse Africa</a>
-									<a class="o-footer__matrix-link" href="//www.boardiq.com/">Board IQ</a>
-									<a class="o-footer__matrix-link" href="//www.ftiecla.com/">Corporate Learning Alliance</a>
-									<a class="o-footer__matrix-link" href="//www.dpn-online.com/">DPN: Deutsche Pensions &amp; Investment Nachrichten</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.execsense.com/">ExecSense</a>
-									<a class="o-footer__matrix-link" href="//www.fdiintelligence.com/">FDI Intelligence</a>
-									<a class="o-footer__matrix-link" href="//financialadvisoriq.com/">Financial Advisor IQ</a>
-									<a class="o-footer__matrix-link" aria-label="F T Chinese" href="//www.ftchinese.com/">FT Chinese</a>
-									<a class="o-footer__matrix-link" aria-label="F T Live" href="//live.ft.com/">FT Live</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" aria-label="F T Property Listings" href="//propertylistings.ft.com/">FT Property Listings</a>
-									<a class="o-footer__matrix-link" aria-label="F T Advisor" href="//www.ftadviser.com/">FT Advisor</a>
-									<a class="o-footer__matrix-link" href="//www.fundfire.com/">Fund Fire</a>
-									<a class="o-footer__matrix-link" href="//www.globalriskregulator.com/">Global Risk Regulator</a>
-									<a class="o-footer__matrix-link" href="//howtospendit.ft.com/">How to Spend It</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.ignites.com/">Ignites</a>
-									<a class="o-footer__matrix-link" href="//www.ignitesasia.com/">Ignites Asia</a>
-									<a class="o-footer__matrix-link" href="//www.igniteseurope.com/">Ignites Europe</a>
-									<a class="o-footer__matrix-link" href="//www.investorschronicle.co.uk/">Investors Chronicle</a>
-									<a class="o-footer__matrix-link" href="//www.mandatewire.com/">Mandate Wire</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.nyif.com/">New York Insitute of Finance</a>
-									<a class="o-footer__matrix-link" href="//www.non-execs.com/">Non Executive Directors Club</a>
-									<a class="o-footer__matrix-link" href="//www.pensions-expert.com/">Pensions Expert</a>
-									<a class="o-footer__matrix-link" href="//www.pwmnet.com/">Professional Wealth Management</a>
-									<a class="o-footer__matrix-link" href="//the125.ft.com/">125 Club</a>
-							</div>
-							<div class="o-footer__matrix-column">
-									<a class="o-footer__matrix-link" href="//www.thebanker.com/">The Banker</a>
-									<a class="o-footer__matrix-link" href="//www.thebankerdatabase.com/">The Banker Database</a>
-									<a class="o-footer__matrix-link" href="//www.thisisafricaonline.com/">This is Africa</a>
-							</div>
-					</div>
-				</div>
 			</nav>
+
+			<h6 class="o-footer__external-link o-footer__matrix-title">
+				<a class="o-footer__more-from-ft o-footer__matrix-title" href="http://ft.com/more-from-ft-group">More from the FT Group</a>
+			</h6>
 		</div>
 
 		<div class="o-footer__copyright" role="contentinfo">
 			<small>
-				Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD {{ now() | strftime('%Y') }}.
-				<abbr title="Financial Times" aria-label="F T">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.<br>
+				Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD  {{ now() | strftime(’%Y’) }}.
+				<abbr title="Financial Times" aria-label="F T">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.<br></br>
 				The Financial Times and its journalism are subject to a self-regulation regime under the <a href="http://www.ft.com/editorialcode" aria-label="F T Editorial Code of Practice">FT Editorial Code of Practice</a>.
 			</small>
 		</div>
@@ -132,4 +89,4 @@
 		</div>
 	</div>
 </footer>
-<script async>queue('https://origami-build.ft.com/v2/bundles/js?export=oFooter&modules=o-footer@^5.0.3', null, true)</script>
+<script async>queue('https://origami-build.ft.com/v2/bundles/js?export=oFooter&modules=o-footer@^5.3.1', null, true)</script>


### PR DESCRIPTION
Hopefully this resolves the [Object doesn't support property or method 'next'][1] errors in Sentry. We're several versions removed from current on header, this mostly just removed the "More from FT Group" segment.

<img width="679" alt="screen shot 2016-12-15 at 13 34 00" src="https://cloud.githubusercontent.com/assets/185041/21225926/3440e9f8-c2cb-11e6-8a81-3dc8cbc0dbcf.png">


[1]: https://sentry.io/nextftcom/ft-ig-static/issues/194013736/activity/